### PR TITLE
Only invoke onChange block if object is changed/deleted/refreshed

### DIFF
--- a/Flapjack/CoreData/SingleCoreDataSource.swift
+++ b/Flapjack/CoreData/SingleCoreDataSource.swift
@@ -133,9 +133,8 @@ public class SingleCoreDataSource<T: NSManagedObject & DataObject>: NSObject, Si
         if let filtered = findObjectFrom(objects: theRest) {
             hasFetched = true
             object = filtered
+            onChange?(object)
         }
-
-        onChange?(object)
     }
 
     @objc

--- a/Tests/CoreData/SingleCoreDataSourceTests.swift
+++ b/Tests/CoreData/SingleCoreDataSourceTests.swift
@@ -74,7 +74,6 @@ class SingleCoreDataSourceTests: XCTestCase {
 
     func testObjectDidChangeBlockFiresForSavesInvolvingObject() {
         let expect = expectation(description: "did change block")
-        expect.expectedFulfillmentCount = 2
         dataSource.onChange = { object in
             expect.fulfill()
         }
@@ -86,7 +85,6 @@ class SingleCoreDataSourceTests: XCTestCase {
 
     func testObjectDidChangeBlockFiresForChangeProcessesInvolvingObject() {
         let expect = expectation(description: "did change block")
-        expect.expectedFulfillmentCount = 2
         dataSource.onChange = { object in
             expect.fulfill()
         }
@@ -101,7 +99,6 @@ class SingleCoreDataSourceTests: XCTestCase {
         dataAccess.mainContext.persist()
 
         let expect = expectation(description: "did change block")
-        expect.expectedFulfillmentCount = 2
         dataSource.onChange = { object in
             expect.fulfill()
         }


### PR DESCRIPTION
This was causing our notification handers to fire no matter what, which isn't good!