### PR TITLE
Change default merge policy for background contexts to favor in-memory changes

### DIFF
--- a/Flapjack/CoreData/CoreDataAccess.swift
+++ b/Flapjack/CoreData/CoreDataAccess.swift
@@ -14,7 +14,7 @@ import Flapjack
 
 /**
  Presides over the setup and management of the entire Core Data stack, along with managing the lifecycle of background
- context operations. Background contexts use the `NSMergeByPropertyObjectTrumpMergePolicy` merge policy, and will share
+ context operations. Background contexts use the `NSMergeByPropertyStoreTrumpMergePolicy` merge policy, and will share
  a persistent store with the `mainContext`, and change synchronization between the contexts are performed by
  `NSPersistentContainer`.
  */
@@ -142,7 +142,7 @@ public final class CoreDataAccess: DataAccess {
      */
     public func performInBackground(operation: @escaping (_ context: DataContext) -> Void) {
         container.performBackgroundTask { context in
-            context.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+            context.mergePolicy = NSMergeByPropertyStoreTrumpMergePolicy
             operation(context)
         }
     }
@@ -156,7 +156,7 @@ public final class CoreDataAccess: DataAccess {
     public func vendBackgroundContext() -> DataContext {
         let context = container.newBackgroundContext()
         context.persistentStoreCoordinator = container.persistentStoreCoordinator
-        context.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+        context.mergePolicy = NSMergeByPropertyStoreTrumpMergePolicy
         return context
     }
 

--- a/Tests/CoreData/CoreDataAccessTests.swift
+++ b/Tests/CoreData/CoreDataAccessTests.swift
@@ -191,7 +191,7 @@ class CoreDataAccessTests: XCTestCase {
                 XCTFail("Couldn't get mergePolicy which is bad.")
                 return
             }
-            XCTAssertEqual(mergePolicy, NSMergeByPropertyObjectTrumpMergePolicy as? NSObject)
+            XCTAssertEqual(mergePolicy, NSMergeByPropertyStoreTrumpMergePolicy as? NSObject)
             expect.fulfill()
         }
         waitForExpectations(timeout: 1.0) { XCTAssertNil($0) }
@@ -202,7 +202,7 @@ class CoreDataAccessTests: XCTestCase {
             XCTFail("Expected a managed object context.")
             return
         }
-        XCTAssertEqual(context.mergePolicy as? NSObject, NSMergeByPropertyObjectTrumpMergePolicy as? NSObject)
+        XCTAssertEqual(context.mergePolicy as? NSObject, NSMergeByPropertyStoreTrumpMergePolicy as? NSObject)
         XCTAssertEqual(context.persistentStoreCoordinator, (dataAccess.mainContext as? NSManagedObjectContext)?.persistentStoreCoordinator)
         XCTAssertNil(context.parent)
     }


### PR DESCRIPTION
Fixed code and tests to use the merge policy for background contexts that favors the in-memory version when properties differ.