### PR TITLE
Fix typos

### DIFF
--- a/Flapjack/Core/DataAccess.swift
+++ b/Flapjack/Core/DataAccess.swift
@@ -12,7 +12,7 @@ import Foundation
 // MARK: - DataAccess
 
 /**
- One of two prominantly-used objects in Flapjack, the `DataAccess` protocol (and those that conform to it) preside over
+ One of two prominently-used objects in Flapjack, the `DataAccess` protocol (and those that conform to it) preside over
  the setup and management of the entire data persistence stack, along with managing the lifecycle of background context
  operations.
  */

--- a/Flapjack/Core/DataContext.swift
+++ b/Flapjack/Core/DataContext.swift
@@ -12,7 +12,7 @@ import Foundation
 // MARK: - DataContext
 
 /**
- One of the two prominantly-used objects in Flapjack, the `DataContext` protocol (and those that conform to it) preside
+ One of the two prominently-used objects in Flapjack, the `DataContext` protocol (and those that conform to it) preside
  over a modifiable and searchable "context" of model objects lifted from a backing store.
  */
 public protocol DataContext {

--- a/docs/Protocols.html
+++ b/docs/Protocols.html
@@ -207,7 +207,7 @@
                     <section class="section">
                       <div class="pointer"></div>
                       <div class="abstract">
-                        <p>One of two prominantly-used objects in Flapjack, the <code>DataAccess</code> protocol (and those that conform to it) preside over
+                        <p>One of two prominently-used objects in Flapjack, the <code>DataAccess</code> protocol (and those that conform to it) preside over
 the setup and management of the entire data persistence stack, along with managing the lifecycle of background context
 operations.</p>
 
@@ -294,7 +294,7 @@ call-and-return lifecycle of the methods presented by conformists to <code><a hr
                     <section class="section">
                       <div class="pointer"></div>
                       <div class="abstract">
-                        <p>One of the two prominantly-used objects in Flapjack, the <code>DataContext</code> protocol (and those that conform to it) preside
+                        <p>One of the two prominently-used objects in Flapjack, the <code>DataContext</code> protocol (and those that conform to it) preside
 over a modifiable and searchable <q>context</q> of model objects lifted from a backing store.</p>
 
                         <a href="Protocols/DataContext.html" class="slightly-smaller">See more</a>

--- a/docs/Protocols/DataAccess.html
+++ b/docs/Protocols/DataAccess.html
@@ -184,7 +184,7 @@
 
                 </div>
               </div>
-            <p>One of two prominantly-used objects in Flapjack, the <code>DataAccess</code> protocol (and those that conform to it) preside over
+            <p>One of two prominently-used objects in Flapjack, the <code>DataAccess</code> protocol (and those that conform to it) preside over
 the setup and management of the entire data persistence stack, along with managing the lifecycle of background context
 operations.</p>
 

--- a/docs/Protocols/DataContext.html
+++ b/docs/Protocols/DataContext.html
@@ -184,7 +184,7 @@
 
                 </div>
               </div>
-            <p>One of the two prominantly-used objects in Flapjack, the <code>DataContext</code> protocol (and those that conform to it) preside
+            <p>One of the two prominently-used objects in Flapjack, the <code>DataContext</code> protocol (and those that conform to it) preside
 over a modifiable and searchable <q>context</q> of model objects lifted from a backing store.</p>
 
           </div>

--- a/docs/docsets/Flapjack.docset/Contents/Resources/Documents/Protocols.html
+++ b/docs/docsets/Flapjack.docset/Contents/Resources/Documents/Protocols.html
@@ -207,7 +207,7 @@
                     <section class="section">
                       <div class="pointer"></div>
                       <div class="abstract">
-                        <p>One of two prominantly-used objects in Flapjack, the <code>DataAccess</code> protocol (and those that conform to it) preside over
+                        <p>One of two prominently-used objects in Flapjack, the <code>DataAccess</code> protocol (and those that conform to it) preside over
 the setup and management of the entire data persistence stack, along with managing the lifecycle of background context
 operations.</p>
 
@@ -294,7 +294,7 @@ call-and-return lifecycle of the methods presented by conformists to <code><a hr
                     <section class="section">
                       <div class="pointer"></div>
                       <div class="abstract">
-                        <p>One of the two prominantly-used objects in Flapjack, the <code>DataContext</code> protocol (and those that conform to it) preside
+                        <p>One of the two prominently-used objects in Flapjack, the <code>DataContext</code> protocol (and those that conform to it) preside
 over a modifiable and searchable <q>context</q> of model objects lifted from a backing store.</p>
 
                         <a href="Protocols/DataContext.html" class="slightly-smaller">See more</a>

--- a/docs/docsets/Flapjack.docset/Contents/Resources/Documents/Protocols/DataAccess.html
+++ b/docs/docsets/Flapjack.docset/Contents/Resources/Documents/Protocols/DataAccess.html
@@ -184,7 +184,7 @@
 
                 </div>
               </div>
-            <p>One of two prominantly-used objects in Flapjack, the <code>DataAccess</code> protocol (and those that conform to it) preside over
+            <p>One of two prominently-used objects in Flapjack, the <code>DataAccess</code> protocol (and those that conform to it) preside over
 the setup and management of the entire data persistence stack, along with managing the lifecycle of background context
 operations.</p>
 

--- a/docs/docsets/Flapjack.docset/Contents/Resources/Documents/Protocols/DataContext.html
+++ b/docs/docsets/Flapjack.docset/Contents/Resources/Documents/Protocols/DataContext.html
@@ -184,7 +184,7 @@
 
                 </div>
               </div>
-            <p>One of the two prominantly-used objects in Flapjack, the <code>DataContext</code> protocol (and those that conform to it) preside
+            <p>One of the two prominently-used objects in Flapjack, the <code>DataContext</code> protocol (and those that conform to it) preside
 over a modifiable and searchable <q>context</q> of model objects lifted from a backing store.</p>
 
           </div>


### PR DESCRIPTION
Hello,

This huge PR will fix : 

- 1 typo in `Flapjack/Core/DataAccess.swift`
- 1 typo in `Flapjack/Core/DataContext.swift`
- 2 typos in `docs/Protocols.html`
- 1 typo in `docs/Protocols/DataAccess.html`
- 1 typo in `docs/Protocols/DataContext.html`
- 2 typos in `docs/docsets/Flapjack.docset/Contents/Resources/Documents/Protocols.html`
- 1 typo in `docs/docsets/Flapjack.docset/Contents/Resources/Documents/Protocols/DataAccess.html`
- 1 typo in `docs/docsets/Flapjack.docset/Contents/Resources/Documents/Protocols/DataContext.html`



Bye! :robot: