### PR TITLE
FIX: Add way to change predicate and sorters for CoreDataSource

### DIFF
--- a/Tests/CoreData/CoreDataSourceTests.swift
+++ b/Tests/CoreData/CoreDataSourceTests.swift
@@ -257,4 +257,16 @@ class CoreDataSourceTests: XCTestCase {
         XCTAssertTrue(dataSource.allObjects.contains(entityFour))
         XCTAssertTrue(dataSource.allObjects.contains(entityOne))
     }
+
+    // MARK: Change predicate
+
+    func testChangePredicate() {
+        let dataSource = CoreDataSource<MockEntity>(dataAccess: dataAccess, sorters: [SortDescriptor("someProperty", ascending: false)])
+        dataSource.startListening()
+        XCTAssertEqual(dataSource.numberOfObjects, 5)
+        dataSource.predicate = NSPredicate(format: "someProperty contains \"zzzz\"")
+        XCTAssertEqual(dataSource.numberOfObjects, 1)
+        dataSource.predicate = nil
+        XCTAssertEqual(dataSource.numberOfObjects, 5)
+    }
 }

--- a/Tests/CoreData/CoreDataSourceTests.swift
+++ b/Tests/CoreData/CoreDataSourceTests.swift
@@ -269,4 +269,13 @@ class CoreDataSourceTests: XCTestCase {
         dataSource.predicate = nil
         XCTAssertEqual(dataSource.numberOfObjects, 5)
     }
+
+    // MARK: Change sorters
+    func testChangeSorters() {
+        let dataSource = CoreDataSource<MockEntity>(dataAccess: dataAccess, sorters: [SortDescriptor("someProperty", ascending: true)])
+        dataSource.startListening()
+        XCTAssertEqual(dataSource.allObjects.first?.someProperty, "someValue aaaa")
+        dataSource.sorters = [SortDescriptor("someProperty", ascending: false)]
+        XCTAssertEqual(dataSource.allObjects.first?.someProperty, "someValue zzzz")
+    }
 }


### PR DESCRIPTION
Add a way to change the predicate associated with a CoreData source
Add a way to change sorters as well
Added tests
