### PR TITLE
FIX: Add the ability to accept `nil` values in NSPredicate+Extensions

### DIFF
--- a/Flapjack/Core/DataContext.swift
+++ b/Flapjack/Core/DataContext.swift
@@ -17,7 +17,7 @@ import Foundation
  */
 public protocol DataContext {
     /// A generic alias for searchable criteria (this often gets converted into an `NSPredicate` under the hood).
-    typealias Attributes = [String: Any]
+    typealias Attributes = [String: Any?]
 
     /**
      Asks the context to perform an operation against itself on an isolated thread or queue.

--- a/Flapjack/Core/Extensions/NSCompoundPredicate+Extensions.swift
+++ b/Flapjack/Core/Extensions/NSCompoundPredicate+Extensions.swift
@@ -9,13 +9,20 @@
 import Foundation
 
 internal extension NSPredicate {
-    class func fromConditions(_ dictionary: [String: Any]) -> [NSPredicate] {
+    class func fromConditions(_ dictionary: [String: Any?]) -> [NSPredicate] {
         return dictionary.compactMap { NSPredicate(key: $0, value: $1) }
     }
 
-    convenience init(key: String, value: Any) {
+    convenience init(key: String, value: Any?) {
         let keyPath = key.hasPrefix("self") ? key : "%K"
-        var args: [Any] = key.hasPrefix("self") ? [value] : [key, value]
+        var args: [Any] = key.hasPrefix("self") ? [] : [key]
+
+        guard let value = value else {
+            self.init(format: "\(keyPath) == nil", argumentArray: args)
+            return
+        }
+
+        args.append(value)
 
         switch value {
         case is [Any], is [AnyHashable], is Set<AnyHashable>:
@@ -54,11 +61,11 @@ internal extension NSPredicate {
 }
 
 internal extension NSCompoundPredicate {
-    convenience init(andPredicateFrom dictionary: [String: Any]) {
+    convenience init(andPredicateFrom dictionary: [String: Any?]) {
         self.init(andPredicateWithSubpredicates: NSPredicate.fromConditions(dictionary))
     }
 
-    convenience init(orPredicateFrom dictionary: [String: Any]) {
+    convenience init(orPredicateFrom dictionary: [String: Any?]) {
         self.init(orPredicateWithSubpredicates: NSPredicate.fromConditions(dictionary))
     }
 }

--- a/Flapjack/CoreData/Extensions/Dictionary+Extensions.swift
+++ b/Flapjack/CoreData/Extensions/Dictionary+Extensions.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-internal extension Dictionary where Key == String, Value == Optional<Any> {
+internal extension Dictionary where Key == String, Value == Any? {
     var cacheKey: String {
         return self.keys.sorted().compactMap { key in
             guard let value = self[key] else {

--- a/Flapjack/CoreData/Extensions/Dictionary+Extensions.swift
+++ b/Flapjack/CoreData/Extensions/Dictionary+Extensions.swift
@@ -8,13 +8,18 @@
 
 import Foundation
 
-internal extension Dictionary where Key == String, Value == Any {
+internal extension Dictionary where Key == String, Value == Optional<Any> {
     var cacheKey: String {
         return self.keys.sorted().compactMap { key in
             guard let value = self[key] else {
                 return nil
             }
-            return "\(key).\(String(describing: value))"
+            switch value {
+            case .some(let inner):
+            return "\(key).\(String(describing: inner))"
+            case .none:
+                return "\(key).nil"
+            }
         }.joined(separator: "-")
     }
 }

--- a/Tests/Core/Extensions/Dictionary+ExtensionsTests.swift
+++ b/Tests/Core/Extensions/Dictionary+ExtensionsTests.swift
@@ -14,10 +14,13 @@ import XCTest
 class DictionaryExtensionsTests: XCTestCase {
     func testCacheKeyGeneration() {
         // Sorts keys and then spits out a key
-        let source: [String: Any] = ["this": "should", "produce": true, "aCacheKey": 42]
+        let source: [String: Any?] = ["this": "should", "produce": true, "aCacheKey": 42]
         XCTAssertEqual(source.cacheKey, "aCacheKey.42-produce.true-this.should")
 
-        let empty = [String: Any]()
+        let empty = [String: Any?]()
         XCTAssertEqual(empty.cacheKey, "")
+
+        let withNil: [String: Any?] = ["this": "should", "appear": nil]
+        XCTAssertEqual(withNil.cacheKey, "appear.nil-this.should")
     }
 }

--- a/Tests/Core/Extensions/NSCompoundPredicate+ExtensionsTests.swift
+++ b/Tests/Core/Extensions/NSCompoundPredicate+ExtensionsTests.swift
@@ -38,4 +38,9 @@ class NSCompoundPredicateExtensionsTests: XCTestCase {
         XCTAssertTrue(predicates.contains { $0.predicateFormat == "one == \"two\"" })
         XCTAssertTrue(predicates.contains { $0.predicateFormat == "three == 4" })
     }
+
+    func testInitializeFromNull() {
+        XCTAssertEqual(NSPredicate(key: "keypath", value: nil).predicateFormat, "keypath == nil")
+        XCTAssertEqual(NSPredicate(key: "self", value: nil).predicateFormat, "SELF == nil")
+    }
 }


### PR DESCRIPTION
Started using Flapjack in a side project and figured I'd add support for this while I was at it!

This closes #28. It's also _probably_ a breaking change, so while it's not necessary for us to immediately bump and create a new version, it should go out next as 0.7.