### PR TITLE
FIX: Ensure CoreDataSource behaves between context deletions

### DIFF
--- a/Flapjack.podspec
+++ b/Flapjack.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name        = 'Flapjack'
-  s.version     = '0.7.0'
+  s.version     = '0.7.1'
   s.summary     = 'A Swift data persistence API with support for Core Data.'
   s.description = <<-DESC
 Flapjack is an iOS/macOS/tvOS framework with 2 primary goals.

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ It lets you _skip_ the boilerplate commonly associated with database layers like
 Flapjack will soon be available through [CocoaPods][cpd]. To install it for now, simply add the following line to your Podfile:
 
 ```ruby
-pod 'Flapjack', git: 'https://github.com/oreillymedia/flapjack.git', tag: '0.6.1'
+pod 'Flapjack', git: 'https://github.com/oreillymedia/flapjack.git', tag: '0.7.1'
 # If you're using Core Data...
-pod 'Flapjack/CoreData', git: 'https://github.com/oreillymedia/flapjack.git', tag: '0.6.1'
+pod 'Flapjack/CoreData', git: 'https://github.com/oreillymedia/flapjack.git', tag: '0.7.1'
 # If you're targeting iOS and want some helpers...
-pod 'Flapjack/UIKit', git: 'https://github.com/oreillymedia/flapjack.git', tag: '0.6.1'
+pod 'Flapjack/UIKit', git: 'https://github.com/oreillymedia/flapjack.git', tag: '0.7.1'
 ```
 
 And run `pod install` at the command line.


### PR DESCRIPTION
This fixes a bug we discovered when deleting our data store — data sources sent out notifications telling collection and table views to dump their contents (which is good!) but those that happened to ask for specific objects at specific index paths still got objects that belonged to old contexts, because we still had the old `NSFetchedResultsController` holding onto its old objects. The tests I added failed before the changes I added.

Now we tell the `NSFetchedResultsController` to re-fetch with a `FALSEPREDICATE` (which is `NSPredicate(value: false)`), guaranteed to empty out the controller's `fetchedObjects`, just before the context is deleted. We store the previous predicate (either an actual object or a `nil` value) in a temporary and aptly-named property, at which point that is restored before we re-fetch once the context is re-created. 