### PR TITLE
Empty out arrays, object counts when context is zombified

### DIFF
--- a/Flapjack.podspec
+++ b/Flapjack.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name        = 'Flapjack'
-  s.version     = '0.7.2'
+  s.version     = '0.7.3'
   s.summary     = 'A Swift data persistence API with support for Core Data.'
   s.description = <<-DESC
 Flapjack is an iOS/macOS/tvOS framework with 2 primary goals.

--- a/Flapjack/Core/Types/DataSourceChange.swift
+++ b/Flapjack/Core/Types/DataSourceChange.swift
@@ -12,7 +12,7 @@ import Foundation
  Describes a change in position for an element observed by a data source. This can be an insertion, a deletion, a move,
  or an update-in-place. Each case comes with the relevant index path information.
  */
-public enum DataSourceChange: CustomStringConvertible, Hashable {
+public enum DataSourceChange: CustomStringConvertible, Hashable, Equatable {
     /// Describes an insertion into the data source's object set at a given index path.
     case insert(path: IndexPath)
     /// Describes a deletion from the data source's object set at a given index path.

--- a/Flapjack/Core/Types/DataSourceSectionChange.swift
+++ b/Flapjack/Core/Types/DataSourceSectionChange.swift
@@ -12,7 +12,7 @@ import Foundation
  Describes a change in position for a section grouping of content observed by a data source. This can be an insertion or
  a deletion. Each case comes with the relevant section index information.
  */
-public enum DataSourceSectionChange: CustomStringConvertible, Hashable {
+public enum DataSourceSectionChange: CustomStringConvertible, Hashable, Equatable {
     /// Describes an insertion of a new section into the data source's grouped object set.
     case insert(section: Int)
     /// Describes a deletion of an existing section from the data source's grouped object set.

--- a/Flapjack/CoreData/CoreDataSource.swift
+++ b/Flapjack/CoreData/CoreDataSource.swift
@@ -146,16 +146,25 @@ public class CoreDataSource<T: NSManagedObject & DataObject>: NSObject, NSFetche
 
     /// Any full section titles for the sections found in the data set, if grouped.
     public var sectionNames: [String] {
+        guard !isContextAZombie else {
+            return []
+        }
         return controller.sections?.compactMap { $0.name } ?? []
     }
 
     /// Any abbreviated section titles for the sections found in the data set, if grouped.
     public var sectionIndexTitles: [String] {
+        guard !isContextAZombie else {
+            return []
+        }
         return controller.sections?.compactMap { $0.indexTitle } ?? []
     }
 
     /// The number of sections detected in the matched data set, if grouped by section. Otherwise, this is `1`.
     public var numberOfSections: Int {
+        guard !isContextAZombie else {
+            return 0
+        }
         return controller.sections?.count ?? 0
     }
 
@@ -197,11 +206,18 @@ public class CoreDataSource<T: NSManagedObject & DataObject>: NSObject, NSFetche
      - returns: The number of objects in that given section.
      */
     public func numberOfObjects(in section: Int) -> Int {
+        guard !isContextAZombie else {
+            return 0
+        }
         return sectionInfo(for: section)?.numberOfObjects ?? 0
     }
 
     /**
      Provides the object matching the given index path, if found.
+
+     This function will still lookup and return object info even when context is about to be
+     deleted, because it is generally not required for table / collection view summation delegate
+     functions (number of sections, number of items per section, etc.).
 
      - parameter indexPath: The index path to use in the lookup.
      - returns: The object, if one is found at the given index path.
@@ -324,26 +340,31 @@ public class CoreDataSource<T: NSManagedObject & DataObject>: NSObject, NSFetche
         //   our number of objects or our array of objects will get back empty ones (so as to
         //   preserve data source functional integrity for collection/table view data sources).
         // If an object needs to get a specific element from us based on these indices, that object
-        //   can still get it before it fully goes away using `object(at:)`.
+        //   can still get it before it fully goes away using `object(at:)` inside of the change
+        //   block. After that invocation of the change block though, the objects are cleared from
+        //   the fetched results controller as well.
         isContextAZombie = true
 
         // Make sure our listener knows our objects are going away
         if hasExecuted {
             if let onChangeBlock = onChange, let fetchedObjects = controller.fetchedObjects as? [T], !fetchedObjects.isEmpty {
                 let itemRemovals: [DataSourceChange] = fetchedObjects.compactMap { indexPath(for: $0) }.map { .delete(path: $0) }
-                let sectionRemovals: [DataSourceSectionChange] = (0..<numberOfSections).map { .delete(section: $0) }
+                let numberOfControllerSections = controller.sections?.count ?? 0
+                let sectionRemovals: [DataSourceSectionChange] = (0..<numberOfControllerSections).map { .delete(section: $0) }
                 onChangeBlock(itemRemovals, sectionRemovals)
             }
 
-            // Give our controller a stub predicate and ask it to fetch, so that it will clear out its fetchedResults.
-            //   This will kick off a new fetch. The old predicate is backed up to `predicateToSurviveContextWipe`, to
-            //   be... well, restored after the context wipe. Note that a `nil` predicate here is still important,
-            //   because no matter what we want to undo this FALSEPREDICATE.
+            // Give our controller a stub predicate and ask it to fetch, so that it will clear out
+            //   its fetchedResults. The old one is backed up to `predicateToSurviveContextWipe`, to
+            //   be... well, restored after the context wipe. Note that a `nil` predicate here is
+            //   still important, because no matter what we want to undo this FALSEPREDICATE.
             predicateToSurviveContextWipe = predicate
             predicate = NSPredicate(value: false)
+            // Call this here instead of relying on `predicate.didSet` which is a no-op if the
+            //   context is marked as a zombie.
+            NSFetchedResultsController<NSManagedObject>.deleteCache(withName: cacheKey)
+            try? controller.performFetch()
         }
-
-        isContextAZombie = true
     }
 
 


### PR DESCRIPTION
With this changeset (which will be released as 0.7.3), we mark our `CoreDataSource` as having a zombie context _earlier_ in its lifecycle (before we notify listeners about the data source emptying out) so that when those listeners (usually collection/table view data sources) ask our `CoreDataSource` how many objects it has, we can return the "accurate" number (which is 0), which prevents inconsistency exceptions.

Objects can still get at specific objects using `object(at:)` and passing in the index paths if they need to, before those objects' backing contexts go away.