### PR TITLE
Use an internally-named logger to avoid name collisions

### DIFF
--- a/Sources/Core/Support/Logger.swift
+++ b/Sources/Core/Support/Logger.swift
@@ -1,5 +1,5 @@
 //
-//  Logger.swift
+//  FJLogger.swift
 //  Flapjack
 //
 //  Created by Ben Kreeger on 5/17/18.
@@ -36,7 +36,7 @@ public enum LoggerLevel: Int, CustomStringConvertible {
 
 /// A logger object used for printing out relevant statements to `os_log`.
 @available(iOS 10.0, *)
-public final class Logger: NSObject {
+public final class FJLogger: NSObject {
     /// The minimum severity level to log; default is `.info`.
     public static var logLevel: LoggerLevel = .info
     /// The `OSLog` to which statements are delivered.

--- a/Sources/CoreData/CoreDataAccess.swift
+++ b/Sources/CoreData/CoreDataAccess.swift
@@ -177,7 +177,7 @@ public final class CoreDataAccess: DataAccess {
                 do {
                     try FileManager.default.removeItem(atPath: storeURL.path)
                 } catch let error {
-                    Logger.error("Error destroying persistent store at \(storeURL): \(error)")
+                    FJLogger.error("Error destroying persistent store at \(storeURL): \(error)")
                 }
             }
             if rebuild {
@@ -195,7 +195,7 @@ public final class CoreDataAccess: DataAccess {
             do {
                 try persistentStoreCoordinator.remove(persistentStore)
             } catch let error {
-                Logger.error("Error removing persistent store #\(idx) \(persistentStore): \(error)")
+                FJLogger.error("Error removing persistent store #\(idx) \(persistentStore): \(error)")
             }
         }
 
@@ -205,7 +205,7 @@ public final class CoreDataAccess: DataAccess {
                 try persistentStoreCoordinator.destroyPersistentStore(at: storeURL, ofType: storeType.coreDataType, options: nil)
                 try FileManager.default.removeItem(atPath: storeURL.path)
             } catch let error {
-                Logger.error("Error destroying persistent store at \(storeURL): \(error)")
+                FJLogger.error("Error destroying persistent store at \(storeURL): \(error)")
             }
         }
 

--- a/Sources/CoreData/CoreDataMigrator.swift
+++ b/Sources/CoreData/CoreDataMigrator.swift
@@ -32,7 +32,7 @@ class CoreDataMigrator: Migrator {
             let data = try Data(contentsOf: compiledModelURL.appendingPathComponent("VersionInfo.plist", isDirectory: false))
             return try PropertyListDecoder().decode(VersionInfo.self, from: data)
         } catch let error {
-            Logger.error("\(error)")
+            FJLogger.error("\(error)")
             return nil
         }
     }()
@@ -41,7 +41,7 @@ class CoreDataMigrator: Migrator {
         do {
             return try NSPersistentStoreCoordinator.metadataForPersistentStore(ofType: storeType.coreDataType, at: storeURL, options: nil)
         } catch let error {
-            Logger.error("\(error)")
+            FJLogger.error("\(error)")
             return nil
         }
     }()
@@ -100,10 +100,10 @@ class CoreDataMigrator: Migrator {
             if let url = tempURL {
                 do {
                     try FileManager.default.removeItem(at: url)
-                    Logger.debug("Successfully removed temporary store file.")
+                    FJLogger.debug("Successfully removed temporary store file.")
                 } catch let error {
                     // This is a non-critical error.
-                    Logger.error("Couldn't remove temporary store file: \(error.localizedDescription)")
+                    FJLogger.error("Couldn't remove temporary store file: \(error.localizedDescription)")
                 }
             }
         }
@@ -114,7 +114,7 @@ class CoreDataMigrator: Migrator {
             return false
         }
         if let first = modelsToMigrate.first?.version, let last = modelsToMigrate.last?.version {
-            Logger.debug("Core Data: need to migrate from version \(first) to version \(last).")
+            FJLogger.debug("Core Data: need to migrate from version \(first) to version \(last).")
         }
 
         var currentURLStore = storeURL
@@ -124,7 +124,7 @@ class CoreDataMigrator: Migrator {
                 let source = modelsToMigrate[idx]
                 let destination = modelsToMigrate[idx + 1]
 
-                Logger.debug("Migrating to \(destination.version).")
+                FJLogger.debug("Migrating to \(destination.version).")
                 let migratedURL = try migrateStore(at: currentURLStore, from: source, to: destination)
                 if idx > 0 {
                     try removeStore(at: currentURLStore)
@@ -141,9 +141,9 @@ class CoreDataMigrator: Migrator {
         do {
             try removeStore(at: storeURL)
             try FileManager.default.moveItem(at: currentURLStore, to: storeURL)
-            Logger.debug("Successfully migrated Core Data store and moved to \(storeURL)")
+            FJLogger.debug("Successfully migrated Core Data store and moved to \(storeURL)")
         } catch let error {
-            Logger.error("Successfully migrated Core Data store, but wasn't able to move to \(storeURL): \(error.localizedDescription)")
+            FJLogger.error("Successfully migrated Core Data store, but wasn't able to move to \(storeURL): \(error.localizedDescription)")
             throw MigratorError.cleanupError(error)
         }
 
@@ -239,7 +239,7 @@ class CoreDataMigrator: Migrator {
         //   model. Any specific mapping model classes are generated from (and referred to in) the
         //   Core Data schema file.
         if let explicitModel = NSMappingModel(from: [bundle], forSourceModel: source.model, destinationModel: destination.model) {
-            Logger.debug("Found concrete mapping model from source model \(source.version) to destination model \(destination.version).")
+            FJLogger.debug("Found concrete mapping model from source model \(source.version) to destination model \(destination.version).")
             return explicitModel
         }
         return try NSMappingModel.inferredMappingModel(forSourceModel: source.model, destinationModel: destination.model)

--- a/Sources/CoreData/CoreDataSource.swift
+++ b/Sources/CoreData/CoreDataSource.swift
@@ -185,13 +185,13 @@ public class CoreDataSource<T: NSManagedObject & DataObject>: NSObject, NSFetche
         NotificationCenter.default.addObserver(self, selector: #selector(contextWillBeDestroyed(_:)), name: CoreDataAccess.willDestroyMainContextNotification, object: nil)
 
         do {
-            Logger.debug("Fetching cache key \"\(cacheKey)\"")
+            FJLogger.debug("Fetching cache key \"\(cacheKey)\"")
             controller.delegate = self
             try controller.performFetch()
             sendCurrentObjects()
             hasExecuted = true
         } catch let error {
-            Logger.error("Error fetching CoreDataSource<\(T.self)>: \(error)")
+            FJLogger.error("Error fetching CoreDataSource<\(T.self)>: \(error)")
         }
     }
 
@@ -230,15 +230,15 @@ public class CoreDataSource<T: NSManagedObject & DataObject>: NSObject, NSFetche
     public func object(at indexPath: IndexPath) -> T? {
         // controller.object(at: indexPath) is garbage. We do this our way.
         guard let info = sectionInfo(for: indexPath.section) else {
-            Logger.error("Couldn't find section info for section \(indexPath.section).")
+            FJLogger.error("Couldn't find section info for section \(indexPath.section).")
             return nil
         }
         guard let objects = info.objects else {
-            Logger.error("Couldn't find objects for section \(indexPath.section), section info \(info).")
+            FJLogger.error("Couldn't find objects for section \(indexPath.section), section info \(info).")
             return nil
         }
         guard indexPath.item < objects.count else {
-            Logger.error("Couldn't find object at given index \(indexPath.item), section \(indexPath.section) among \(objects.count) objects.")
+            FJLogger.error("Couldn't find object at given index \(indexPath.item), section \(indexPath.section) among \(objects.count) objects.")
             return nil
         }
         return objects[indexPath.item] as? T
@@ -318,7 +318,7 @@ public class CoreDataSource<T: NSManagedObject & DataObject>: NSObject, NSFetche
             try controller.performFetch()
             sendCurrentObjects()
         } catch let error {
-            Logger.error("Error fetching CoreDataSource<\(T.self)>: \(error)")
+            FJLogger.error("Error fetching CoreDataSource<\(T.self)>: \(error)")
         }
     }
 
@@ -393,9 +393,9 @@ public class CoreDataSource<T: NSManagedObject & DataObject>: NSObject, NSFetche
             return
         }
 
-        Logger.debug("\(#function): (\(T.self))")
+        FJLogger.debug("\(#function): (\(T.self))")
         guard let change = theType.asDataSourceSectionChange(section: sectionIndex) else {
-            Logger.error("No section change calculated for \(theType), index \(sectionIndex))")
+            FJLogger.error("No section change calculated for \(theType), index \(sectionIndex))")
             return
         }
         pendingSectionChanges.append(change)
@@ -407,7 +407,7 @@ public class CoreDataSource<T: NSManagedObject & DataObject>: NSObject, NSFetche
         }
 
         guard let change = theType.asDataSourceChange(at: indexPath, newPath: newIndexPath) else {
-            Logger.error("No change calculated for \(theType), indexPath \(String(describing: indexPath)), newIndexPath: \(String(describing: newIndexPath))")
+            FJLogger.error("No change calculated for \(theType), indexPath \(String(describing: indexPath)), newIndexPath: \(String(describing: newIndexPath))")
             return
         }
 

--- a/Sources/CoreData/Extensions/NSManagedObjectContext+DataContext.swift
+++ b/Sources/CoreData/Extensions/NSManagedObjectContext+DataContext.swift
@@ -69,7 +69,7 @@ extension NSManagedObjectContext: DataContext {
         if self.persist() == nil {
             return true
         }
-        Logger.error("Rolling back Core Data store.")
+        FJLogger.error("Rolling back Core Data store.")
         rollback()
         return false
     }
@@ -87,7 +87,7 @@ extension NSManagedObjectContext: DataContext {
             try self.save()
             return nil
         } catch let error {
-            Logger.error("Error saving context \(printableAddress): \(error)")
+            FJLogger.error("Error saving context \(printableAddress): \(error)")
             return .saveError(error)
         }
     }
@@ -111,7 +111,7 @@ extension NSManagedObjectContext: DataContext {
         do {
             return try fetchObjects(ofType: type, predicate: predicate, prefetch: prefetch ?? [], sortBy: sorters, limit: limit)
         } catch let error {
-            Logger.error("Error fetching objects \(type) with predicate \(String(describing: predicate)): \(error.localizedDescription)")
+            FJLogger.error("Error fetching objects \(type) with predicate \(String(describing: predicate)): \(error.localizedDescription)")
             return []
         }
     }
@@ -146,7 +146,7 @@ extension NSManagedObjectContext: DataContext {
         do {
             return try count(for: request)
         } catch {
-            Logger.error("Error fetching count of \(type) with predicate \(String(describing: predicate)): \(error.localizedDescription)")
+            FJLogger.error("Error fetching count of \(type) with predicate \(String(describing: predicate)): \(error.localizedDescription)")
             return 0
         }
     }
@@ -170,7 +170,7 @@ extension NSManagedObjectContext: DataContext {
         do {
             return try fetchObject(ofType: type, predicate: predicate, prefetch: prefetch ?? [], sortBy: sorters)
         } catch let error {
-            Logger.error("Error fetching objects \(type) with predicate \(String(describing: predicate)): \(error.localizedDescription)")
+            FJLogger.error("Error fetching objects \(type) with predicate \(String(describing: predicate)): \(error.localizedDescription)")
             return nil
         }
     }
@@ -197,7 +197,7 @@ extension NSManagedObjectContext: DataContext {
             }
             return found as? T
         } catch let error {
-            Logger.error("Error finding object by ID \(objectID): \(error)")
+            FJLogger.error("Error finding object by ID \(objectID): \(error)")
             return nil
         }
     }

--- a/Sources/CoreData/Extensions/NSMigrationManager+Extensions.swift
+++ b/Sources/CoreData/Extensions/NSMigrationManager+Extensions.swift
@@ -53,7 +53,7 @@ public extension NSMigrationManager {
                 return try destinationContext.fetch(request)
             }
         } catch let error {
-            Logger.error(error.localizedDescription)
+            FJLogger.error(error.localizedDescription)
             return []
         }
     }

--- a/Tests/CoreData/CoreDataAccessTests.swift
+++ b/Tests/CoreData/CoreDataAccessTests.swift
@@ -214,9 +214,9 @@ class CoreDataAccessTests: XCTestCase {
         XCTAssertEqual(context.persistentStoreCoordinator, (dataAccess.mainContext as? NSManagedObjectContext)?.persistentStoreCoordinator)
         XCTAssertNil(context.parent)
     }
-    
+
     // MARK: - Context Propagation Testing
-    
+
     func testMainContextGetsCorrectPolicy() {
         dataAccess = CoreDataAccess(name: "TestModel", type: .memory, model: model, delegate: delegate, defaultPolicy: .rollback)
         guard let mergePolicy = (dataAccess.mainContext as? NSManagedObjectContext)?.mergePolicy as? NSObject else {
@@ -225,7 +225,7 @@ class CoreDataAccessTests: XCTestCase {
         }
         XCTAssertEqual(mergePolicy, NSRollbackMergePolicy as? NSObject)
     }
-    
+
     func testVendBackgroundContextGetsCorrectPolicy() {
         dataAccess = CoreDataAccess(name: "TestModel", type: .memory, model: model, delegate: delegate, defaultPolicy: .overwrite)
         guard let context = dataAccess.vendBackgroundContext() as? NSManagedObjectContext else {
@@ -234,7 +234,7 @@ class CoreDataAccessTests: XCTestCase {
         }
         XCTAssertEqual(context.mergePolicy as? NSObject, NSOverwriteMergePolicy as? NSObject)
     }
-    
+
     func testPerformInBackgroundContextGetsCorrectPolicy() {
         dataAccess = CoreDataAccess(name: "TestModel", type: .memory, model: model, delegate: delegate, defaultPolicy: .rollback)
         let expect = expectation(description: "operation")
@@ -248,7 +248,6 @@ class CoreDataAccessTests: XCTestCase {
         }
         waitForExpectations(timeout: 1.0) { XCTAssertNil($0) }
     }
-    
 }
 
 

--- a/Tests/CoreData/CoreDataMigratorTests.swift
+++ b/Tests/CoreData/CoreDataMigratorTests.swift
@@ -40,7 +40,7 @@ class CoreDataMigratorTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        Logger.logLevel = .debug
+        FJLogger.logLevel = .debug
         urlsToCleanup = [URL]()
     }
 


### PR DESCRIPTION
When the Flapjack module is imported into other projects that also import a module with a `Logger` object, the compiler doesn't know which one is which.  
But, making the Flapjack `Logger` internal-only doesn't work, because it is contained in the `Flapjack` target, but is used by other packages like `FlapjackCoreData`.

So, we could either create a new local package which moves the Logger into its own package that is only used by other Flapjack packages, or rename it to fix the naming conflicts.

I've done the renaming here, but am open to the separate package solution if that would be preferable.

