### PR TITLE
SPARK: Add support for async calls

### DIFF
--- a/Flapjack.xcodeproj/project.pbxproj
+++ b/Flapjack.xcodeproj/project.pbxproj
@@ -191,6 +191,9 @@
 		C3F8CCC121C468A300199781 /* TestMigrationModel 3.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = C3F8CCC021C468A300199781 /* TestMigrationModel 3.xcmappingmodel */; };
 		C3F8CCC421C468DC00199781 /* TestMigrationModel 4.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = C3F8CCC321C468DC00199781 /* TestMigrationModel 4.xcmappingmodel */; };
 		C3F8CCCA21C46ADE00199781 /* MockMigrationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3F8CCC921C46ADE00199781 /* MockMigrationPolicy.swift */; };
+		E4A6667A2A9671890037D91D /* DataContextScheduledTaskType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A666792A9671890037D91D /* DataContextScheduledTaskType.swift */; };
+		E4A6667B2A9671890037D91D /* DataContextScheduledTaskType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A666792A9671890037D91D /* DataContextScheduledTaskType.swift */; };
+		E4A6667C2A9671890037D91D /* DataContextScheduledTaskType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A666792A9671890037D91D /* DataContextScheduledTaskType.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -383,6 +386,7 @@
 		C3F8CCC021C468A300199781 /* TestMigrationModel 3.xcmappingmodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcmappingmodel; path = "TestMigrationModel 3.xcmappingmodel"; sourceTree = "<group>"; };
 		C3F8CCC321C468DC00199781 /* TestMigrationModel 4.xcmappingmodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcmappingmodel; path = "TestMigrationModel 4.xcmappingmodel"; sourceTree = "<group>"; };
 		C3F8CCC921C46ADE00199781 /* MockMigrationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMigrationPolicy.swift; sourceTree = "<group>"; };
+		E4A666792A9671890037D91D /* DataContextScheduledTaskType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataContextScheduledTaskType.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -663,6 +667,7 @@
 				C34587FE2696192A00817250 /* DataSourceChange.swift */,
 				C34587FF2696192A00817250 /* DataAccessError.swift */,
 				C34588002696192A00817250 /* DataSourceSectionChange.swift */,
+				E4A666792A9671890037D91D /* DataContextScheduledTaskType.swift */,
 			);
 			path = Types;
 			sourceTree = "<group>";
@@ -1395,6 +1400,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C345882C2696193900817250 /* SingleDataSource.swift in Sources */,
+				E4A6667A2A9671890037D91D /* DataContextScheduledTaskType.swift in Sources */,
 				C34588402696194F00817250 /* PrimaryKey.swift in Sources */,
 				C34588282696193900817250 /* DataSource.swift in Sources */,
 				C345883D2696194F00817250 /* DataSourceChange.swift in Sources */,
@@ -1468,6 +1474,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C345883A2696193A00817250 /* SingleDataSource.swift in Sources */,
+				E4A6667C2A9671890037D91D /* DataContextScheduledTaskType.swift in Sources */,
 				C34588562696195000817250 /* PrimaryKey.swift in Sources */,
 				C34588362696193A00817250 /* DataSource.swift in Sources */,
 				C34588532696195000817250 /* DataSourceChange.swift in Sources */,
@@ -1579,6 +1586,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C34588332696193900817250 /* SingleDataSource.swift in Sources */,
+				E4A6667B2A9671890037D91D /* DataContextScheduledTaskType.swift in Sources */,
 				C345884B2696195000817250 /* PrimaryKey.swift in Sources */,
 				C345882F2696193900817250 /* DataSource.swift in Sources */,
 				C34588482696195000817250 /* DataSourceChange.swift in Sources */,
@@ -2009,6 +2017,7 @@
 				DEVELOPMENT_TEAM = 5XJYJPRTH5;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "Tests/Info-iOS.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -2035,6 +2044,7 @@
 				DEVELOPMENT_TEAM = 5XJYJPRTH5;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "Tests/Info-iOS.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "-DCOCOAPODS";

--- a/Sources/Core/DataAccess.swift
+++ b/Sources/Core/DataAccess.swift
@@ -45,6 +45,9 @@ public protocol DataAccess {
      */
     func performInBackground(operation: @escaping (_ context: DataContext) -> Void)
 
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func performBackgroundTask<T>(_ block: @escaping (DataContext) throws -> T) async rethrows -> T
+
     /**
      Invoking this method should ask the `DataAccess` object to prepare a background-thread `DataContext` for use, and
      then return that context right away on the calling thread. It should be the caller's responsibility to use the

--- a/Sources/Core/DataContext.swift
+++ b/Sources/Core/DataContext.swift
@@ -34,6 +34,12 @@ public protocol DataContext {
      */
     func performSync(_ operation: @escaping (_ context: DataContext) -> Void)
 
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func perform<T>(schedule: DataContextScheduledTaskType, _ block: @escaping (_ context: DataContext) throws -> T) async rethrows -> T
+
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func perform<T>(_ block: @escaping (_ context: DataContext) throws -> T) async rethrows -> T
+
     /**
      Asks the context to go through any unsaved modifications and do anything short of saving them to the disk; this may
      include giving new objects unique identifiers, establishing relationships in an object graph, etc.

--- a/Sources/Core/Types/DataContextScheduledTaskType.swift
+++ b/Sources/Core/Types/DataContextScheduledTaskType.swift
@@ -1,0 +1,14 @@
+//
+//  DataContextScheduledTaskType.swift
+//  Flapjack
+//
+//  Created by Laura Dickey on 8/23/23.
+//  Copyright © 2023 O'Reilly Media, Inc. All rights reserved.
+//
+
+import Foundation
+
+public enum DataContextScheduledTaskType: Hashable, Equatable {
+    case enqueued
+    case immediate
+}

--- a/Sources/CoreData/CoreDataAccess.swift
+++ b/Sources/CoreData/CoreDataAccess.swift
@@ -147,6 +147,14 @@ public final class CoreDataAccess: DataAccess {
         }
     }
 
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    public func performBackgroundTask<T>(_ block: @escaping (DataContext) throws -> T) async rethrows -> T {
+        return try await container.performBackgroundTask { [defaultContextPolicy] context in
+            context.mergePolicy = defaultContextPolicy
+            return try block(context)
+        }
+    }
+
     /**
      Prepares a background-thread `DataContext` for use, and then returns that context right away on the calling thread.
      It should be the caller's responsibility to use the context responsibly.

--- a/Sources/CoreData/Extensions/NSManagedObjectContext+DataContext.swift
+++ b/Sources/CoreData/Extensions/NSManagedObjectContext+DataContext.swift
@@ -34,6 +34,22 @@ extension NSManagedObjectContext: DataContext {
         self.performAndWait { operation(self) }
     }
 
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    public func perform<T>(schedule: DataContextScheduledTaskType = .immediate, _ block: @escaping (_ context: DataContext) throws -> T) async rethrows -> T {
+        let mocSchedule: ScheduledTaskType = {
+            switch schedule {
+            case .immediate: return .immediate
+            case .enqueued: return .enqueued
+            }
+        }()
+        return try await self.perform(schedule: mocSchedule) { try block(self) }
+    }
+
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    public func perform<T>(_ block: @escaping (DataContext) throws -> T) async rethrows -> T {
+        return try await self.perform(schedule: .immediate) { try block(self) }
+    }
+
     /**
      Goes back to this context's backing store to get a new copy of the requested object (which dumps its
      potentially-cached version).

--- a/Tests/CoreData/CoreDataAccessTests.swift
+++ b/Tests/CoreData/CoreDataAccessTests.swift
@@ -205,6 +205,19 @@ class CoreDataAccessTests: XCTestCase {
         waitForExpectations(timeout: 1.0) { XCTAssertNil($0) }
     }
 
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func testAsyncPerformInBackgroundContext() async throws {
+        let value = await dataAccess.performBackgroundTask { context in
+            guard let mergePolicy = (context as? NSManagedObjectContext)?.mergePolicy as? NSObject else {
+                XCTFail("Couldn't get mergePolicy which is bad.")
+                return ""
+            }
+            XCTAssertEqual(mergePolicy, NSMergeByPropertyStoreTrumpMergePolicy as? NSObject)
+            return "done"
+        }
+        XCTAssertEqual(value, "done")
+    }
+
     func testVendBackgroundContext() {
         guard let context = dataAccess.vendBackgroundContext() as? NSManagedObjectContext else {
             XCTFail("Expected a managed object context.")

--- a/Tests/CoreData/Extensions/NSManagedObjectContextDataContextTests.swift
+++ b/Tests/CoreData/Extensions/NSManagedObjectContextDataContextTests.swift
@@ -56,6 +56,14 @@ class NSManagedObjectContextDataContextTests: XCTestCase {
         }
     }
 
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func testAsyncPerformWithBlock() async throws {
+        let val = await context.perform { innerContext in
+            XCTAssertEqual(innerContext as? NSManagedObjectContext, self.context)
+            return "passed"
+        }
+        XCTAssertEqual(val, "passed")
+    }
 
     // MARK: - Persistence calls
 


### PR DESCRIPTION
Now that CoreData supports async/await in newer versions of its supported OSes, add a wrapper in Flapjack to allow similar async/await calls.
