### PR TITLE
SPARK: Add a persist call that throws, to improve flow at call site

### DIFF
--- a/Sources/Core/DataContext.swift
+++ b/Sources/Core/DataContext.swift
@@ -64,6 +64,14 @@ public protocol DataContext {
     func persist() -> DataContextError?
 
     /**
+     Asks the context to save any pending changes to its backing store. If no changes are detected, this method should
+     not invoke an unnecessary save.
+
+     - throws: An error if one occurred while saving.
+     */
+    func persistOrThrow() throws
+
+    /**
      Asks the context to save any pending changes to its backing store, but if it encounters an error, it should attempt
      a rollback and return whether or not the save succeeded.
 

--- a/Sources/CoreData/Extensions/NSManagedObjectContext+DataContext.swift
+++ b/Sources/CoreData/Extensions/NSManagedObjectContext+DataContext.swift
@@ -75,6 +75,12 @@ extension NSManagedObjectContext: DataContext {
         return forcePersist()
     }
 
+    public func persistOrThrow() throws {
+        if let err = persist() {
+            throw err
+        }
+    }
+
     /**
      Save any pending changes to our backing store, but if we encounter an error, attempts a rollback and returns
      whether or not the save succeeded.

--- a/Tests/CoreData/Extensions/NSManagedObjectContextDataContextTests.swift
+++ b/Tests/CoreData/Extensions/NSManagedObjectContextDataContextTests.swift
@@ -86,6 +86,30 @@ class NSManagedObjectContextDataContextTests: XCTestCase {
         waitForExpectations(timeout: 1.0) { XCTAssertNil($0) }
     }
 
+    func testPersistOrThrow() throws {
+        expectation(forNotification: .NSManagedObjectContextDidSave, object: context, handler: nil)
+
+        // Without changes, a notification is not fired.
+        try context.persistOrThrow()
+
+        // With invalid changes, a notification is not fired.
+        let mock = context.create(MockEntity.self)
+        mock.someProperty = nil
+        do {
+            try context.persistOrThrow()
+            XCTAssertNotNil(nil)
+        } catch {
+            XCTAssertNotNil(error)
+        }
+
+        // With valid changes, a notification is fired.
+        mock.someProperty = "valid value"
+        try context.persistOrThrow()
+
+        // Thus our expectation should only get called once.
+        waitForExpectations(timeout: 1.0) { XCTAssertNil($0) }
+    }
+
     func testPersistOrRollback() {
         expectation(forNotification: .NSManagedObjectContextDidSave, object: context, handler: nil)
 


### PR DESCRIPTION
Just a simple wrapper around persist that throws the error instead of returning it.

Unfortunately, due to name conflicts, it had to have a different name.
