### PR TITLE
GUAC-4726 Fix small bugs in SingleCoreDataSource

### DIFF
--- a/Sources/CoreData/SingleCoreDataSource.swift
+++ b/Sources/CoreData/SingleCoreDataSource.swift
@@ -127,7 +127,10 @@ public class SingleCoreDataSource<T: NSManagedObject & DataObject>: NSObject, Si
             hasFetched = true
             object = nil
             onChange?(nil)
-        } else if let filtered = findObjectFrom(objects: inserts.union(updates).union(refreshes)) {
+        }
+
+        let theRest = inserts.union(updates).union(refreshes)
+        if let filtered = findObjectFrom(objects: theRest) {
             hasFetched = true
             object = filtered
             onChange?(object)

--- a/Sources/CoreData/SingleCoreDataSource.swift
+++ b/Sources/CoreData/SingleCoreDataSource.swift
@@ -106,6 +106,7 @@ public class SingleCoreDataSource<T: NSManagedObject & DataObject>: NSObject, Si
         }
 
         object = context.object(ofType: T.self, predicate: predicate, prefetch: prefetch, sortBy: [])
+        hasFetched = true
         onChange?(object)
     }
 
@@ -113,7 +114,7 @@ public class SingleCoreDataSource<T: NSManagedObject & DataObject>: NSObject, Si
     // MARK: Private functions
 
     private func findObjectFrom(objects: Set<T>) -> T? {
-        return (objects as NSSet).filtered(using: predicate).first(where: { $0 is T }) as? T
+        return objects.first { predicate.evaluate(with: $0) }
     }
 
     @objc
@@ -126,10 +127,7 @@ public class SingleCoreDataSource<T: NSManagedObject & DataObject>: NSObject, Si
             hasFetched = true
             object = nil
             onChange?(nil)
-        }
-
-        let theRest = inserts.union(updates).union(refreshes)
-        if let filtered = findObjectFrom(objects: theRest) {
+        } else if let filtered = findObjectFrom(objects: inserts.union(updates).union(refreshes)) {
             hasFetched = true
             object = filtered
             onChange?(object)
@@ -143,6 +141,7 @@ public class SingleCoreDataSource<T: NSManagedObject & DataObject>: NSObject, Si
 
         // Store our newly-minted context, and refetch.
         self.context = newContext
+        isContextAZombie = false
         startListening()
     }
 

--- a/Tests/CoreData/SingleCoreDataSourceTests.swift
+++ b/Tests/CoreData/SingleCoreDataSourceTests.swift
@@ -174,9 +174,9 @@ class SingleCoreDataSourceTests: XCTestCase {
         XCTAssertEqual(dataSource.object, newEntity)
     }
 
-    func testObjectDidChangeBlockFiresTwiceWhenOldObjectIsDeletedAndNewOneCreated() {
+    func testObjectDidChangeBlockOnlyFiresOnceWhenOldObjectIsDeletedAndNewOneCreated() {
         let expect = expectation(description: "did change block")
-        expect.expectedFulfillmentCount = 3
+        expect.expectedFulfillmentCount = 2
         dataSource.onChange = { _ in
             expect.fulfill()
         }
@@ -188,6 +188,7 @@ class SingleCoreDataSourceTests: XCTestCase {
         dataAccess.mainContext.persist()
 
         waitForExpectations(timeout: 0.5) { XCTAssertNil($0) }
-        XCTAssertEqual(dataSource.object, newEntity)
+        // If the object has been deleted, it should not be returned by the object property
+        XCTAssertNil(dataSource.object)
     }
 }

--- a/Tests/CoreData/SingleCoreDataSourceTests.swift
+++ b/Tests/CoreData/SingleCoreDataSourceTests.swift
@@ -174,9 +174,9 @@ class SingleCoreDataSourceTests: XCTestCase {
         XCTAssertEqual(dataSource.object, newEntity)
     }
 
-    func testObjectDidChangeBlockOnlyFiresOnceWhenOldObjectIsDeletedAndNewOneCreated() {
+    func testObjectDidChangeBlockFiresTwiceWhenOldObjectIsDeletedAndNewOneCreated() {
         let expect = expectation(description: "did change block")
-        expect.expectedFulfillmentCount = 2
+        expect.expectedFulfillmentCount = 3
         dataSource.onChange = { _ in
             expect.fulfill()
         }
@@ -188,7 +188,6 @@ class SingleCoreDataSourceTests: XCTestCase {
         dataAccess.mainContext.persist()
 
         waitForExpectations(timeout: 0.5) { XCTAssertNil($0) }
-        // If the object has been deleted, it should not be returned by the object property
-        XCTAssertNil(dataSource.object)
+        XCTAssertEqual(dataSource.object, newEntity)
     }
 }


### PR DESCRIPTION
When a user calls `startListening`, a fetch is done, so `hasFetched` should be set to true.

Also, if an object is deleted, there is no point in sending out any earlier modified messages for the object. Just send out the delete, and update the test to reflect this.

If a context has been deleted, and the single core data source is restarted with a new context, clear the zombie flag.


## Notes

Originally, the ticket was just for the first issue. But, while I was there, asked Claude if there were any other bugs, and it identified the first one, along with the other two.  

The second issue could be a matter of style, but it doesn't seem to make much sense to send out change notifications for an objects that is about to be deleted. Just delete it.  If there is a need to send out both notifications, perhaps the delete could be sent out *after* the other modification, but it shouldn't be sent out before.

I don't think our usage of this library in puffin ever reuses a SingleCoreDataSource, but the zombie flag being reset seems like a good idea.
